### PR TITLE
Update the knife.rb snippet to be more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ provided by Chef, not as a gem.
 
 In your `knife.rb` file, add this snippet:
 
-    unless chefdk.nil?
-      require 'chef_gen/template'
+    # only load ChefGen::Flavors if we're being called from the ChefDK CLI
+    if defined?(ChefDK::CLI)
+      require 'chef_gen/flavors'
       chefdk.generator_cookbook = ChefGen::Flavors.path
     end
 


### PR DESCRIPTION
Update the knife.rb snippet to be more robust to running from a bundle that doesn't
include chef-gen-flavors or things that use Buff::Config (which creates a proxy for
things it doesn't understand, causing `chefdk.nil?` to return true when berkshelf
reads your config)

[ci skip]
