### PR TITLE
Copy the contents of the selected flavor to a temporary path

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,8 @@
-# Changelog for chef-gen-template
+# Changelog for chef-gen-flavors
+
+## 0.6.0
+
+* copy the contents of the code generator to a temporary path.  This is foundational work for allow snippets to include content as well as resource declarations
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ The directory structure of a plugin looks like this:
             └── flavor
                 └── example.rb
 
+It is important that the name of the directory in which your generator
+cookbook lives matches the name in metadata.rb.  ChefDK uses the last
+element of the path as the cookbook name, so if you put your cookbook
+in a folder called 'cookbook' but your metadata.rb declares the name
+as 'code_generator', ChefDK won't be able to find your recipe.
+
 ## ALTERNATE code_generator PATHS
 
 By default, the code_generator cookbook is assumed to live in a directory
@@ -153,6 +159,21 @@ method like this:
 For compatibility with all platforms supported by ChefDK, plugins should use
 the methods in the `File` class to construct relative paths rather than
 assuming what the path separator should be.
+
+## GENERATOR PATH COPY
+
+When #path is called, chef-gen-flavors makes a copy of the selected
+generator cookbook to a temporary path, which is what gets returned
+and used by ChefDK.  This path is cleaned up at exit unless the environment
+variable CHEFGEN_NOCLEANTMP is set.
+
+This temporary path is set as an attribute in the ChefDK Generator
+context, and can be retrieved in a flavor by calling
+
+    ChefDK::Generator.context.generator_path
+
+This is foundational work to allow snippets to include content as well
+as declarations of what files they will render.
 
 ## FLAVOR BASE CLASS
 

--- a/spec/lib/chef_gen/flavors_spec.rb
+++ b/spec/lib/chef_gen/flavors_spec.rb
@@ -103,14 +103,30 @@ RSpec.describe ChefGen::Flavors do
   it 'should default the code_generator path' do
     ChefGen::Flavors.disregard_plugin :baz
     ENV['CHEFGEN_FLAVOR'] = 'Foo'
-    expect(ChefGen::Flavors.path)
-      .to match(%r{spec/support/fixtures/code_generator$})
+    expect(FileUtils).to receive(:cp_r).with(
+      %r{spec/support/fixtures/code_generator$}, String
+    )
+    ChefGen::Flavors.path
   end
 
   it 'should respect an overridden code_generator path' do
     ChefGen::Flavors.disregard_plugin :baz
     ENV['CHEFGEN_FLAVOR'] = 'Bar'
+    expect(FileUtils).to receive(:cp_r).with(
+      %r{spec/support/fixtures/code_generator_2$}, String
+    )
+    ChefGen::Flavors.path
+  end
+
+  it 'should copy the code_generator to a temp directory' do
+    ChefGen::Flavors.disregard_plugin :baz
+    ENV['CHEFGEN_FLAVOR'] = 'Foo'
+    tmpdir = Dir.tmpdir
+    expect(FileUtils).to receive(:cp_r).with(
+      %r{spec/support/fixtures/code_generator$},
+      %r{#{tmpdir}/chefgen_flavor\..+$}
+    )
     expect(ChefGen::Flavors.path)
-      .to match(%r{spec/support/fixtures/code_generator_2$})
+      .to match(%r{#{tmpdir}/chefgen_flavor\..+$})
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,7 @@ module ChefDKGeneratorContext
     allow(@ctx).to receive(:cookbook_name).and_return('foo')
     allow(@ctx).to receive(:have_git).and_return(true)
     allow(@ctx).to receive(:skip_git_init).and_return(false)
+    allow(@ctx).to receive(:generator_path=)
     allow(ChefDK::Generator).to receive(:context).and_return(@ctx)
   end
 end


### PR DESCRIPTION
and pass that to ChefDK.  This is foundational work to allow snippets to carry content as well as declarations.
Version bump to 0.6.0