### PR TITLE
Enable public and private Supermarket sources.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 # Changelog for chef-gen-flavors
 
+## 0.8.4
+* Specify minimum `berkshelf` version of '3.3' in generated Gemfile. Berkshelf
+3.3+ support `no_proxy` env var so you can download from Public and private
+supermarket sources in your Berksfile.
+
 ## 0.8.3
 
 * TestKitchen snippet: give the dummy task created when TK cannot initalize (e.g. vagrant not installed) a description so it shows up in the output of 'rake -T'

--- a/lib/chef_gen/flavors.rb
+++ b/lib/chef_gen/flavors.rb
@@ -8,7 +8,7 @@ module ChefGen
   # a plugin framework for creating ChefDK generator flavors
   class Flavors
     # the version of the gem
-    VERSION = '0.8.3'
+    VERSION = '0.8.4'
 
     extend LittlePlugger path: 'chef_gen/flavor',
                          module: ChefGen::Flavor

--- a/lib/chef_gen/flavors/cucumber/knife.rb
+++ b/lib/chef_gen/flavors/cucumber/knife.rb
@@ -1,6 +1,6 @@
 Given(/^a knife.rb that uses chef-gen-flavors$/) do
   write_file 'knife.rb', <<END
-cookbook_path '#{File.expand_path(current_dir)}'
+cookbook_path '#{File.expand_path(current_directory)}'
 require 'chef_gen/flavors'
 chefdk.generator_cookbook = ChefGen::Flavors.path
 END

--- a/lib/chef_gen/snippet/cookbook_base.rb
+++ b/lib/chef_gen/snippet/cookbook_base.rb
@@ -35,7 +35,7 @@ module ChefGen
           'pry-byebug' => '~> 3.1',
           'pry-rescue' => '~> 1.4',
           'pry-stack_explorer' => '~> 0.4',
-          'berkshelf' => '~> 3.2',
+          'berkshelf' => '~> 3.3',
           'guard' => '~> 2.12'
         }
       end

--- a/spec/lib/chef_gen/flavor_base_spec.rb
+++ b/spec/lib/chef_gen/flavor_base_spec.rb
@@ -50,20 +50,20 @@ RSpec.describe ChefGen::FlavorBase do
     template.generate
   end
 
-  it 'creates files conditionally with the clobber check enabled' do
+  it 'creates files conditionally with the clobber check enabled', :focus do
     include FakeFS::SpecHelpers
 
     expect(@recipe).to receive(:directory).once
     expect(@recipe).not_to receive(:cookbook_file)
     expect(File).to receive(:exist?)
-      .with('/nonexistent/foo/README.md')
+      .with(%r{/nonexistent/foo/README.md})
       .and_return(true)
     template = ChefGen::Flavor::Amazing.new(@recipe)
     template.fail_on_clobber = true
     template.files << 'README.md'
     expect { template.generate }
       .to output(/tried to overwrite file.+README\.md/).to_stderr
-      .and raise_error
+       .and raise_error(RuntimeError)
   end
 
   it 'creates files conditionally with the clobber check disabled' do
@@ -93,14 +93,14 @@ RSpec.describe ChefGen::FlavorBase do
     expect(@recipe).to receive(:directory).once
     expect(@recipe).not_to receive(:template)
     expect(File).to receive(:exist?)
-      .with('/nonexistent/foo/README.md')
+      .with(%r{/nonexistent/foo/README.md})
       .and_return(true)
     template = ChefGen::Flavor::Amazing.new(@recipe)
     template.fail_on_clobber = true
     template.templates << 'README.md'
     expect { template.generate }
       .to output(/tried to overwrite file.+README\.md/).to_stderr
-      .and raise_error
+      .and raise_error(RuntimeError)
   end
 
   it 'creates templates conditionally with the clobber check disabled' do

--- a/spec/lib/chef_gen/flavor_base_spec.rb
+++ b/spec/lib/chef_gen/flavor_base_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ChefGen::FlavorBase do
     template.generate
   end
 
-  it 'creates files conditionally with the clobber check enabled', :focus do
+  it 'creates files conditionally with the clobber check enabled' do
     include FakeFS::SpecHelpers
 
     expect(@recipe).to receive(:directory).once

--- a/spec/lib/chef_gen/flavors_spec.rb
+++ b/spec/lib/chef_gen/flavors_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ChefGen::Flavors do
     to_disregard.each do |plugin|
       ChefGen::Flavors.disregard_plugin plugin
     end
-    expect { ChefGen::Flavors.path }.to raise_error
+    expect { ChefGen::Flavors.path }.to raise_error(RuntimeError)
   end
 
   it 'should use the builtin flavor as an option with the env var set' do
@@ -93,7 +93,8 @@ RSpec.describe ChefGen::Flavors do
 
   it 'should raise an error if the plugin has no description' do
     ENV['CHEFGEN_FLAVOR'] = 'Baz'
-    expect { ChefGen::Flavors.path }.to raise_error
+    expect { ChefGen::Flavors.path }.to raise_error(
+      NameError, /^undefined method/)
   end
 
   it 'should default the code_generator path' do


### PR DESCRIPTION
Specify minimum `berkshelf` version of '3.3' in generated Gemfile. Berkshelf
3.3+ supports the `no_proxy` env var so you can download from Public and private
supermarket sources in your Berksfile.

Also make specs work on Windows.