### PR TITLE
* pin to Aruba 0.6.x

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 # Changelog for chef-gen-flavors
 
+## 0.8.5
+
+* pin to Aruba 0.6.x because of the incompatible changes in subprocess working directories introduced in 0.7
+* revert 'current_dir' change in 0.8.4, which was only required due to upgrading Aruba
+
 ## 0.8.4
 * Specify minimum `berkshelf` version of '3.3' in generated Gemfile. Berkshelf
 3.3+ support `no_proxy` env var so you can download from Public and private

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,10 @@ begin
     extra_dev_deps << ['simplecov', '~> 0.9']
     extra_dev_deps << ['simplecov-console', '~> 0.2']
     extra_dev_deps << ['yard', '~> 0.8']
-    extra_dev_deps << ['aruba', '~> 0.6']
+    # aruba 0.7 and higher have completely changed subprocess
+    # working dirs and I've not yet found how to make it work
+    # with our feature tests
+    extra_dev_deps << ['aruba', '~> 0.6.2']
     extra_dev_deps << ['rspec_junit_formatter', '~> 0.2']
     extra_dev_deps << ['fakefs', '~> 0.6']
   end

--- a/chef-gen-flavors.gemspec
+++ b/chef-gen-flavors.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: chef-gen-flavors 0.8.3.20150619073155 ruby lib
+# stub: chef-gen-flavors 0.8.5.20150716103945 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "chef-gen-flavors"
-  s.version = "0.8.3.20150619073155"
+  s.version = "0.8.5.20150716103945"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["James FitzGibbon"]
-  s.date = "2015-06-19"
+  s.date = "2015-07-16"
   s.description = "chef-gen-flavors is a framework for creating custom templates for the\n'chef generate' command provided by ChefDK.\n\nThis gem simply provides a framework; templates are provided by separate\ngems, which you can host privately for use within your organization or\npublicly for the Chef community to use.\n\nAt present this is focused primarily on providing templates for generation of\ncookbooks, as this is where most organization-specific customization takes place.\nSupport for the other artifacts that ChefDK can generate may work, but is not\nthe focus of early releases."
   s.email = ["james.i.fitzgibbon@nordstrom.com"]
   s.extra_rdoc_files = ["ARUBA_STEPS.md", "History.md", "Manifest.txt", "README.md"]
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<simplecov>, ["~> 0.9"])
       s.add_development_dependency(%q<simplecov-console>, ["~> 0.2"])
       s.add_development_dependency(%q<yard>, ["~> 0.8"])
-      s.add_development_dependency(%q<aruba>, ["~> 0.6"])
+      s.add_development_dependency(%q<aruba>, ["~> 0.6.2"])
       s.add_development_dependency(%q<rspec_junit_formatter>, ["~> 0.2"])
       s.add_development_dependency(%q<fakefs>, ["~> 0.6"])
     else
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<simplecov>, ["~> 0.9"])
       s.add_dependency(%q<simplecov-console>, ["~> 0.2"])
       s.add_dependency(%q<yard>, ["~> 0.8"])
-      s.add_dependency(%q<aruba>, ["~> 0.6"])
+      s.add_dependency(%q<aruba>, ["~> 0.6.2"])
       s.add_dependency(%q<rspec_junit_formatter>, ["~> 0.2"])
       s.add_dependency(%q<fakefs>, ["~> 0.6"])
     end
@@ -77,7 +77,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<simplecov>, ["~> 0.9"])
     s.add_dependency(%q<simplecov-console>, ["~> 0.2"])
     s.add_dependency(%q<yard>, ["~> 0.8"])
-    s.add_dependency(%q<aruba>, ["~> 0.6"])
+    s.add_dependency(%q<aruba>, ["~> 0.6.2"])
     s.add_dependency(%q<rspec_junit_formatter>, ["~> 0.2"])
     s.add_dependency(%q<fakefs>, ["~> 0.6"])
   end

--- a/lib/chef_gen/flavors.rb
+++ b/lib/chef_gen/flavors.rb
@@ -8,7 +8,7 @@ module ChefGen
   # a plugin framework for creating ChefDK generator flavors
   class Flavors
     # the version of the gem
-    VERSION = '0.8.4'
+    VERSION = '0.8.5'
 
     extend LittlePlugger path: 'chef_gen/flavor',
                          module: ChefGen::Flavor

--- a/lib/chef_gen/flavors/cucumber/knife.rb
+++ b/lib/chef_gen/flavors/cucumber/knife.rb
@@ -1,6 +1,6 @@
 Given(/^a knife.rb that uses chef-gen-flavors$/) do
   write_file 'knife.rb', <<END
-cookbook_path '#{File.expand_path(current_directory)}'
+cookbook_path '#{File.expand_path(current_dir)}'
 require 'chef_gen/flavors'
 chefdk.generator_cookbook = ChefGen::Flavors.path
 END


### PR DESCRIPTION
* pin to Aruba 0.6.x because of the incompatible changes in subproces…s working directories introduced in 0.7
* revert 'current_dir' change in 0.8.4, which was only required due to upgrading Aruba